### PR TITLE
fix(transactions): use timestamp instead of createdAt

### DIFF
--- a/app/(app)/transactions/[txId]/index.tsx
+++ b/app/(app)/transactions/[txId]/index.tsx
@@ -44,7 +44,7 @@ export default function Transactions() {
               Transaction {truncateMiddle(transaction.signature)}
             </Heading>
             <Heading textAlign="center" color="$textLight200" size="md" paddingHorizontal="$4" pb="$8">
-              {dayjs(transaction.createdAt).format(DATE_FORMAT)}
+              {dayjs.unix(transaction.timestamp).format(DATE_FORMAT)}
             </Heading>
             <Text color="$textLight400" bold fontSize="$sm" paddingEnd="$4">
               Account:

--- a/components/transactions/MinimalTransactionsCard.tsx
+++ b/components/transactions/MinimalTransactionsCard.tsx
@@ -8,7 +8,7 @@ import { replaceSolanaAddressesWithTruncated } from '@/utils/addresses';
 
 type IProps = MinimalTransaction;
 
-const MinimalTransactionsCard: React.FC<IProps> = ({ virtualAddress, id, createdAt, labels, description }) => {
+const MinimalTransactionsCard: React.FC<IProps> = ({ virtualAddress, id, timestamp, labels, description }) => {
   return (
     <Link href={`/transactions/${id}`} asChild>
       <Pressable>
@@ -34,7 +34,7 @@ const MinimalTransactionsCard: React.FC<IProps> = ({ virtualAddress, id, created
               )}
           </Text>
           <Text pt="$1" fontSize="$xs" color="$textLight400">
-            {dayjs(createdAt).format(DATE_FORMAT)}
+            {dayjs.unix(timestamp).format(DATE_FORMAT)}
           </Text>
         </VStack>
       </Pressable>

--- a/services/transactions/transactions.service.ts
+++ b/services/transactions/transactions.service.ts
@@ -3,7 +3,14 @@ import { request } from '@services/request';
 import { MinimalTransaction, Transaction } from '@/types/transactions.types';
 import { VirtualAddress } from '@/types/virtualAddress.types';
 
-export const getTransactions = async ({ pageParam }: { pageParam?: { after: Transaction['id'] } }) => {
+export const getTransactions = async ({
+  pageParam,
+}: {
+  pageParam?: {
+    id: number;
+    timestamp: number;
+  };
+}) => {
   const res = await request<{ transactions: MinimalTransaction[] }>('me/transactions/paginated', {
     params: pageParam,
   });
@@ -11,7 +18,10 @@ export const getTransactions = async ({ pageParam }: { pageParam?: { after: Tran
   return {
     items: res.transactions,
     hasMore: res.transactions.length !== 0,
-    nextCursor: res.transactions[res.transactions.length - 1]?.id,
+    nextCursor: {
+      id: res.transactions[res.transactions.length - 1]?.id,
+      timestamp: res.transactions[res.transactions.length - 1]?.timestamp,
+    },
   };
 };
 

--- a/services/transactions/useTransactionsLoader.tsx
+++ b/services/transactions/useTransactionsLoader.tsx
@@ -26,7 +26,12 @@ const useTransactionsLoader = () => {
     queryKey: [transactionListCacheKey],
     queryFn: getTransactions,
     getNextPageParam: (lastPage) => {
-      return lastPage.hasMore ? { after: lastPage.nextCursor } : undefined;
+      return lastPage.hasMore
+        ? {
+            after_id: lastPage.nextCursor.id,
+            after_timestamp: lastPage.nextCursor.timestamp,
+          }
+        : undefined;
     },
     onError: () => {
       toast.show({

--- a/types/transactions.types.ts
+++ b/types/transactions.types.ts
@@ -18,6 +18,6 @@ export type Transaction = {
   createdAt: Date;
 };
 
-export type MinimalTransaction = Pick<Transaction, 'id' | 'createdAt' | 'labels' | 'customNote' | 'description'> & {
+export type MinimalTransaction = Pick<Transaction, 'id' | 'timestamp' | 'labels' | 'customNote' | 'description'> & {
   virtualAddress: Pick<VirtualAddress, 'title' | 'address'>;
 };


### PR DESCRIPTION
because it is more accurate of when the transaction happened, also send the cursor (last item) id and timestamp to fetch the next page to get items sorted by timestamp